### PR TITLE
Add GraalVM EE (Enterprise Edition)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,8 @@ jobs:
           - 11
           - 17
           - 19
+          - 11-EE
+          - 17-EE
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/11-EE/Dockerfile
+++ b/11-EE/Dockerfile
@@ -1,0 +1,43 @@
+# ----------------------------------
+# Pterodactyl Core Dockerfile
+# Environment: Java
+# Minimum Panel Version: 1.7.0
+# ----------------------------------
+FROM ubuntu:22.04
+
+ARG GRAAL_VERSION=22.3.0
+ARG JAVA_VERSION=11
+
+MAINTAINER RikoDEV, <kontakt@riko.dev>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+ && apt-get install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 \
+ && export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
+    "linux/amd64")   echo "amd64"  ;; \
+    "linux/arm64")   echo "aarch64" ;; \
+    *)               echo ""        ;; esac) \
+  && echo "ARCH=$ARCH" \
+  && curl --retry 3 -Lfso /tmp/graalvm.tar.gz https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA${JAVA_VERSION}_${GRAAL_VERSION//./_}/graalvm-ee-java${JAVA_VERSION}-linux-${ARCH}-${GRAAL_VERSION}.tar.gz \
+  && mkdir -p /opt/java/graalvm \
+  && cd /opt/java/graalvm \
+  && tar -xf /tmp/graalvm.tar.gz --strip-components=1 \
+  && export PATH="/opt/java/graalvm/bin:$PATH" \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /tmp/graalvm.tar.gz
+
+ENV JAVA_HOME=/opt/java/graalvm \
+    PATH="/opt/java/graalvm/bin:$PATH"
+
+# Step 2 - add pterodactyl stuff
+RUN useradd -d /home/container -m container
+
+USER        container
+ENV         USER=container HOME=/home/container
+
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+
+CMD         ["/bin/bash", "/entrypoint.sh"]

--- a/11-EE/entrypoint.sh
+++ b/11-EE/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+cd /home/container
+
+# Output Current Java Version
+java -version ## only really needed to show what version is being used. Should be changed for different applications
+
+# Replace Startup Variables
+MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+${MODIFIED_STARTUP}

--- a/17-EE/Dockerfile
+++ b/17-EE/Dockerfile
@@ -1,0 +1,43 @@
+# ----------------------------------
+# Pterodactyl Core Dockerfile
+# Environment: Java
+# Minimum Panel Version: 1.7.0
+# ----------------------------------
+FROM ubuntu:22.04
+
+ARG GRAAL_VERSION=22.3.0
+ARG JAVA_VERSION=17
+
+MAINTAINER RikoDEV, <kontakt@riko.dev>
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y \
+ && apt-get install -y curl ca-certificates openssl git tar sqlite3 fontconfig tzdata iproute2 \
+ && export ARCH=$(case ${TARGETPLATFORM:-linux/amd64} in \
+    "linux/amd64")   echo "amd64"  ;; \
+    "linux/arm64")   echo "aarch64" ;; \
+    *)               echo ""        ;; esac) \
+  && echo "ARCH=$ARCH" \
+  && curl --retry 3 -Lfso /tmp/graalvm.tar.gz https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA${JAVA_VERSION}_${GRAAL_VERSION//./_}/graalvm-ee-java${JAVA_VERSION}-linux-${ARCH}-${GRAAL_VERSION}.tar.gz \
+  && mkdir -p /opt/java/graalvm \
+  && cd /opt/java/graalvm \
+  && tar -xf /tmp/graalvm.tar.gz --strip-components=1 \
+  && export PATH="/opt/java/graalvm/bin:$PATH" \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /tmp/graalvm.tar.gz
+
+ENV JAVA_HOME=/opt/java/graalvm \
+    PATH="/opt/java/graalvm/bin:$PATH"
+
+# Step 2 - add pterodactyl stuff
+RUN useradd -d /home/container -m container
+
+USER        container
+ENV         USER=container HOME=/home/container
+
+WORKDIR     /home/container
+
+COPY        ./entrypoint.sh /entrypoint.sh
+
+CMD         ["/bin/bash", "/entrypoint.sh"]

--- a/17-EE/entrypoint.sh
+++ b/17-EE/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+cd /home/container
+
+# Print Java version
+java -version
+
+# Make internal Docker IP address available to processes.
+export INTERNAL_IP=`ip route get 1 | awk '{print $NF;exit}'`
+
+# Replace Startup Variables
+MODIFIED_STARTUP=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`
+echo ":/home/container$ ${MODIFIED_STARTUP}"
+
+# Run the Server
+eval ${MODIFIED_STARTUP}

--- a/README.md
+++ b/README.md
@@ -3,18 +3,33 @@
 ![license mit](https://img.shields.io/badge/license-MIT-green)
 
 GraalVM is a high-performance runtime that provides significant improvements in application performance and efficiency which is ideal for microservices. https://www.graalvm.org/
+
 ___
+
 ## Docker Container Configuration
 
-### Version: GraalVM 22.3.0 | Java 11
+### Version: GraalVM (CE, Community Edition) 22.3.0 | Java 11
+
 > ghcr.io/rikodev/pterodactyl-graalvm:11
 
-### Version: GraalVM 22.3.0 | Java 17
+**Enterprise Edition (EE):**
+
+> ghcr.io/rikodev/pterodactyl-graalvm:11-EE
+
+### Version: GraalVM (CE, Community Edition) 22.3.0 | Java 17
+
 > ghcr.io/rikodev/pterodactyl-graalvm:17
 
-### Version: GraalVM 22.3.0 | Java 19
+**Enterprise Edition (EE):**
+
+> ghcr.io/rikodev/pterodactyl-graalvm:17-EE
+
+### Version: GraalVM (CE, Community Edition) 22.3.0 | Java 19
+
 > ghcr.io/rikodev/pterodactyl-graalvm:19
 
 ___
+
 ## Sponsor
+
 [![poszukaj.se](https://poszukaj.se/storage/branding/wetrackyouplay.jpg)](https://poszukaj.se/)


### PR DESCRIPTION
Adds GraalVM Enterprise Edition versions, which offer more customisability and better performance than the standard/open source GraalVM Community Edition.

**Credit:** https://github.com/brucethemoose/Minecraft-Performance-Flags-Benchmarks

**Note:** There is not a GraalVM EE Java 19 version yet with this direct download link.

<details>
  <summary>Java 17</summary>

- Windows: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA17_22_3_0/graalvm-ee-java17-windows-amd64-22.3.0.zip
    
- Linux AMD64: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA17_22_3_0/graalvm-ee-java17-linux-amd64-22.3.0.tar.gz
    
- Linux ARM: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA17_22_3_0/graalvm-ee-java17-linux-aarch64-22.3.0.tar.gz

- Mac AMD64: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA17_22_3_0/graalvm-ee-java17-darwin-amd64-22.3.0.tar.gz
    
</details>

<details>
  <summary>Java 11</summary>

- Windows: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA11_22_3_0/graalvm-ee-java11-windows-amd64-22.3.0.zip
    
- Linux AMD64: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA11_22_3_0/graalvm-ee-java11-linux-amd64-22.3.0.tar.gz
    
- Linux ARM: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA11_22_3_0/graalvm-ee-java11-linux-aarch64-22.3.0.tar.gz

- Mac AMD64: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA11_22_3_0/graalvm-ee-java11-darwin-amd64-22.3.0.tar.gz
    
</details>

<details>
  <summary>Java 8</summary>

- Windows: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA8_21_3_4/graalvm-ee-java8-windows-amd64-21.3.4.zip
    
- Linux AMD64: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA8_21_3_4/graalvm-ee-java8-linux-amd64-21.3.4.tar.gz

- Mac AMD64: https://oca.opensource.oracle.com/gds/GRAALVM_EE_JAVA8_21_3_4/graalvm-ee-java8-darwin-amd64-21.3.4.tar.gz
    
</details>